### PR TITLE
取得できるコメントがなくなるまでコメントを取得します

### DIFF
--- a/nicochannel_comment.py
+++ b/nicochannel_comment.py
@@ -329,11 +329,11 @@ def get_all_comments(user_token: str, comments_group_id: str) -> list:
         comments_data = get_comments(user_token, comments_group_id, oldest_time)
         if comments_data is None:
             return None
+        if len(comments_data) == 0:
+            break
         comments.extend(comments_data)
         logger.debug(f'{len(comments_data)} コメントを取得しました.')
         logger.info(f'現在 {len(comments)} 個のコメントを取得済み')
-        if len(comments_data) < 120:
-            break
         oldest_time = comments_data[-1]['created_at']
         oldest_time_dt = datetime.strptime(oldest_time, "%Y-%m-%dT%H:%M:%S.%fZ")
         new_oldest_time_dt = oldest_time_dt + timedelta(milliseconds=1)


### PR DESCRIPTION
一回取得できるコメントが120個未満の時も取得されていないコメントが存在しますので、判断基準を取得できるコメントが0個にした方が的確だと思います。
log例：
INFO:__main__:現在 120 個のコメントを取得済み
INFO:__main__:現在 239 個のコメントを取得済み
INFO:__main__:現在 359 個のコメントを取得済み
INFO:__main__:現在 479 個のコメントを取得済み
INFO:__main__:現在 599 個のコメントを取得済み
INFO:__main__:現在 719 個のコメントを取得済み
INFO:__main__:現在 837 個のコメントを取得済み
INFO:__main__:現在 920 個のコメントを取得済み